### PR TITLE
Add Crime Brasil to Geolocation & Maps OSINT (Brazil open crime data)

### DIFF
--- a/README.md
+++ b/README.md
@@ -566,6 +566,7 @@ cat live_subs.txt | eyewitness --web -d screenshots/
 | **Zoom Earth** | Real-time satellite & weather | [zoom.earth](https://zoom.earth/) |
 | **KartaView** | Street-level imagery (OpenStreetCam) | [kartaview.org](https://kartaview.org/) |
 | **ShadowMap** | Shadow analysis for time estimation | [shadowmap.org](https://shadowmap.org/) |
+| **Crime Brasil** | Brazil crime + accidents open data by neighborhood (bairro-level RS; municipal MG/RJ; PRF accidents) | [crimebrasil.com.br](https://crimebrasil.com.br) |
 
 ---
 


### PR DESCRIPTION
Adds [Crime Brasil](https://crimebrasil.com.br) — an open crime-data platform for Brazil — to the most thematically-relevant section of this list.

**Dataset scope:**
- Rio Grande do Sul: 2.99M individual crime records 2022–2026, bairro-level granularity across 497 municipalities + 79K neighborhoods, ~99.99% geocoded
- Minas Gerais: ~965K violent crime records (municipality-level aggregates, SEJUSP)
- Rio de Janeiro: ~37K ISP/CISP records (municipality-level)
- National: PRF DATATRAN (federal highway accidents 2020–2026) + DATASUS SINAN (interpersonal violence 2009–2024)

**Access:** Free public REST API, CSV/Parquet exports, daily incremental updates, CC BY 4.0 license. Documentation at https://crimebrasil.com.br/api/docs.

Disclosure: I'm the maintainer of Crime Brasil.