### PR TITLE
Add insto to OSINT tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 <br/>
 
-[![Tools](https://img.shields.io/badge/Tools-751%2B-FF4444?style=for-the-badge&logo=target&logoColor=white)](https://github.com/rawfilejson/awesome-osint-arsenal)
+[![Tools](https://img.shields.io/badge/Tools-752%2B-FF4444?style=for-the-badge&logo=target&logoColor=white)](https://github.com/rawfilejson/awesome-osint-arsenal)
 [![Categories](https://img.shields.io/badge/Categories-50-0066CC?style=for-the-badge&logo=buffer&logoColor=white)](https://github.com/rawfilejson/awesome-osint-arsenal)
 [![Version](https://img.shields.io/badge/Version-2.1-00CC66?style=for-the-badge&logoColor=white)](https://github.com/rawfilejson/awesome-osint-arsenal)
 [![Updated](https://img.shields.io/badge/Updated-2026--05--10-FF8800?style=for-the-badge&logoColor=white)](https://github.com/rawfilejson/awesome-osint-arsenal)
@@ -18,7 +18,7 @@
 
 <br/>
 
-> **751+ tools · 50 categories · Multi-distro installers · Georgian OSINT · Termux support**
+> **752+ tools · 50 categories · Multi-distro installers · Georgian OSINT · Termux support**
 >
 > *The most comprehensive OSINT and security toolkit on the internet — every tool with installation instructions or a verified link.*
 
@@ -75,7 +75,7 @@ bash termux.sh            # 📱 Android (Termux subset, no sudo needed)
 > [!IMPORTANT]
 > ## 🙏 A note before you fork
 >
-> This repo has **751 tools across 50 categories**. Keeping that current — links, install commands, new tools every week — is a *lot* for one person.
+> This repo has **752 tools across 50 categories**. Keeping that current — links, install commands, new tools every week — is a *lot* for one person.
 >
 > **If nobody helps, parts of this list will go stale.** That's just real talk.
 >
@@ -312,7 +312,7 @@ Tools installed via `apt`/`pip`/`go install` are already on your `$PATH`.
 
 | 🛠️ Total Tools | 💻 CLI Tools | 📁 GitHub Repos | 🌐 Online Platforms | 🤖 AI Tools |
 |:-:|:-:|:-:|:-:|:-:|
-| **751+** | **165+** | **117+** | **461+** | **25+** |
+| **752+** | **166+** | **117+** | **461+** | **25+** |
 
 | 🕶️ Dark Web | 🇬🇪 Georgian OSINT | 💥 Breach Engines | ⚔️ Red Team | 🛡️ Blue Team |
 |:-:|:-:|:-:|:-:|:-:|
@@ -654,6 +654,7 @@ exiftool /path/to/images/
 |------|-------------|----------------|
 | **Osintgram** | Instagram OSINT tool | `git clone https://github.com/Datalux/Osintgram` |
 | **Instaloader** | Instagram data downloader | `pip install instaloader` |
+| **insto** | Interactive Instagram OSINT CLI with REPL, snapshots, diffs, and Maltego exports | `pip install insto` |
 | **Twint** | Twitter OSINT (no API needed) | `pip install twint` |
 | **snscrape** | Social media scraper (Twitter, Reddit, etc.) | `pip install snscrape` |
 | **Toutatis** | Instagram OSINT by phone/email | `pip install toutatis` |
@@ -1977,6 +1978,7 @@ sudo git clone https://github.com/RedSiege/EyeWitness
 | **[IKnowYour.Dad](https://iknowyour.dad)** | Data breach search engine | [iknowyour.dad](https://iknowyour.dad) |
 | **[Imgur](https://imgur.com)** | Image hosting — meme tracing and reverse search | [imgur.com](https://imgur.com) |
 | **instagram_monitor** | Real-time tracking of Instagram users with email alerts and CSV logs | `git clone https://github.com/misiektoja/instagram_monitor.git` |
+| **insto** | Interactive Instagram OSINT CLI with snapshots, diffs, and Maltego-ready exports | `pip3 install insto` |
 | **[Intelligence X (intelx.io)](https://intelx.io)** | Selective archive search — emails, leaks, paste sites, dark-web | [intelx.io](https://intelx.io) |
 | **Interlace** | Easily turn single-threaded CLI apps into multi-threaded jobs | `git clone https://github.com/codingo/Interlace.git` |
 | **[Joe Sandbox](https://www.joesandbox.com)** | Deep automated malware analysis (free tier) | [joesandbox.com](https://www.joesandbox.com) |

--- a/osint.sh
+++ b/osint.sh
@@ -169,7 +169,7 @@ detect_distro
 bootstrap_basics
 
 echo
-say "Installing: 👤 Username & Social Media OSINT (33 tools)"
+say "Installing: 👤 Username & Social Media OSINT (34 tools)"
 install_git https://github.com/ArthurHeitmann/arctic_shift.git arctic_shift       # Arctic Shift
 install_pip blackbird-osint                                                       # Blackbird
 install_git https://github.com/misiektoja/github_monitor.git github_monitor       # github_monitor
@@ -178,6 +178,7 @@ install_go github.com/ibnaleem/gosearch@latest gosearch                         
 install_pip holehe                                                                # Holehe
 install_git https://github.com/misiektoja/instagram_monitor.git instagram_monitor # instagram_monitor
 install_pip instaloader                                                           # Instaloader
+install_pip insto                                                                 # insto
 install_go github.com/tdh8316/investigo@latest investigo                          # Investigo
 install_git https://github.com/l4rm4nd/LinkedInDumper.git LinkedInDumper          # LinkedInDumper
 install_pip maigret                                                               # Maigret

--- a/tools.json
+++ b/tools.json
@@ -7565,6 +7565,30 @@
     "archived": false
   },
   {
+    "id": "insto",
+    "name": "insto",
+    "description": "Interactive Instagram OSINT CLI with REPL, one-shot mode, snapshots, diffs, and Maltego-ready exports",
+    "category": "username-social",
+    "url": "https://github.com/subzeroid/insto",
+    "install": {
+      "method": "pip",
+      "kali": "`pip install insto`",
+      "raw": "`pip install insto`"
+    },
+    "tags": [
+      "username-social",
+      "curated-addition"
+    ],
+    "source_versions": [
+      "v3.3-expansion"
+    ],
+    "aliases": [],
+    "sections_seen": [
+      "Social Media Monitoring"
+    ],
+    "archived": false
+  },
+  {
     "id": "intel-471",
     "name": "Intel 471",
     "description": "Cybercrime intelligence platform",


### PR DESCRIPTION
## Summary
- Add `insto` to `tools.json` under `username-social`.
- Add README entries for Social Media Monitoring and the alphabetical Extra Tools list.
- Add `install_pip insto` to `osint.sh` and update visible tool counts from 751 to 752.

## Verification
- `jq empty tools.json`
- `jq 'length' tools.json` -> `752`
- `bash -n osint.sh install.sh blueteam.sh extras.sh forensics.sh hardware.sh labs.sh redteam.sh termux.sh`
- `git diff --check`
- `git ls-remote https://github.com/subzeroid/insto.git HEAD`
- `curl -fsSL https://pypi.org/pypi/insto/json | jq -r '.info.name + " " + .info.version + " " + .info.project_url'` -> `insto 0.7.15 https://pypi.org/project/insto/`
