### PR TITLE
Add insta-dl to OSINT tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 <br/>
 
-[![Tools](https://img.shields.io/badge/Tools-751%2B-FF4444?style=for-the-badge&logo=target&logoColor=white)](https://github.com/rawfilejson/awesome-osint-arsenal)
+[![Tools](https://img.shields.io/badge/Tools-752%2B-FF4444?style=for-the-badge&logo=target&logoColor=white)](https://github.com/rawfilejson/awesome-osint-arsenal)
 [![Categories](https://img.shields.io/badge/Categories-50-0066CC?style=for-the-badge&logo=buffer&logoColor=white)](https://github.com/rawfilejson/awesome-osint-arsenal)
 [![Version](https://img.shields.io/badge/Version-2.1-00CC66?style=for-the-badge&logoColor=white)](https://github.com/rawfilejson/awesome-osint-arsenal)
 [![Updated](https://img.shields.io/badge/Updated-2026--05--10-FF8800?style=for-the-badge&logoColor=white)](https://github.com/rawfilejson/awesome-osint-arsenal)
@@ -18,7 +18,7 @@
 
 <br/>
 
-> **751+ tools · 50 categories · Multi-distro installers · Georgian OSINT · Termux support**
+> **752+ tools · 50 categories · Multi-distro installers · Georgian OSINT · Termux support**
 >
 > *The most comprehensive OSINT and security toolkit on the internet — every tool with installation instructions or a verified link.*
 
@@ -75,7 +75,7 @@ bash termux.sh            # 📱 Android (Termux subset, no sudo needed)
 > [!IMPORTANT]
 > ## 🙏 A note before you fork
 >
-> This repo has **751 tools across 50 categories**. Keeping that current — links, install commands, new tools every week — is a *lot* for one person.
+> This repo has **752 tools across 50 categories**. Keeping that current — links, install commands, new tools every week — is a *lot* for one person.
 >
 > **If nobody helps, parts of this list will go stale.** That's just real talk.
 >
@@ -312,7 +312,7 @@ Tools installed via `apt`/`pip`/`go install` are already on your `$PATH`.
 
 | 🛠️ Total Tools | 💻 CLI Tools | 📁 GitHub Repos | 🌐 Online Platforms | 🤖 AI Tools |
 |:-:|:-:|:-:|:-:|:-:|
-| **751+** | **165+** | **117+** | **461+** | **25+** |
+| **752+** | **166+** | **117+** | **461+** | **25+** |
 
 | 🕶️ Dark Web | 🇬🇪 Georgian OSINT | 💥 Breach Engines | ⚔️ Red Team | 🛡️ Blue Team |
 |:-:|:-:|:-:|:-:|:-:|
@@ -654,6 +654,7 @@ exiftool /path/to/images/
 |------|-------------|----------------|
 | **Osintgram** | Instagram OSINT tool | `git clone https://github.com/Datalux/Osintgram` |
 | **Instaloader** | Instagram data downloader | `pip install instaloader` |
+| **insta-dl** | Async Instagram downloader with HikerAPI and optional aiograpi backends | `pip install instagram-dl` |
 | **Twint** | Twitter OSINT (no API needed) | `pip install twint` |
 | **snscrape** | Social media scraper (Twitter, Reddit, etc.) | `pip install snscrape` |
 | **Toutatis** | Instagram OSINT by phone/email | `pip install toutatis` |
@@ -1976,6 +1977,7 @@ sudo git clone https://github.com/RedSiege/EyeWitness
 | **[Hybrid Analysis](https://www.hybrid-analysis.com)** | Free advanced malware analysis service by CrowdStrike | [hybrid-analysis.com](https://www.hybrid-analysis.com) |
 | **[IKnowYour.Dad](https://iknowyour.dad)** | Data breach search engine | [iknowyour.dad](https://iknowyour.dad) |
 | **[Imgur](https://imgur.com)** | Image hosting — meme tracing and reverse search | [imgur.com](https://imgur.com) |
+| **insta-dl** | Async Instagram downloader for profiles, posts, reels, stories, highlights, hashtags, and comments | `pip3 install instagram-dl` |
 | **instagram_monitor** | Real-time tracking of Instagram users with email alerts and CSV logs | `git clone https://github.com/misiektoja/instagram_monitor.git` |
 | **[Intelligence X (intelx.io)](https://intelx.io)** | Selective archive search — emails, leaks, paste sites, dark-web | [intelx.io](https://intelx.io) |
 | **Interlace** | Easily turn single-threaded CLI apps into multi-threaded jobs | `git clone https://github.com/codingo/Interlace.git` |

--- a/osint.sh
+++ b/osint.sh
@@ -169,7 +169,7 @@ detect_distro
 bootstrap_basics
 
 echo
-say "Installing: 👤 Username & Social Media OSINT (33 tools)"
+say "Installing: 👤 Username & Social Media OSINT (34 tools)"
 install_git https://github.com/ArthurHeitmann/arctic_shift.git arctic_shift       # Arctic Shift
 install_pip blackbird-osint                                                       # Blackbird
 install_git https://github.com/misiektoja/github_monitor.git github_monitor       # github_monitor
@@ -177,6 +177,7 @@ install_pip gitrecon                                                            
 install_go github.com/ibnaleem/gosearch@latest gosearch                           # GoSearch
 install_pip holehe                                                                # Holehe
 install_git https://github.com/misiektoja/instagram_monitor.git instagram_monitor # instagram_monitor
+install_pip instagram-dl                                                          # insta-dl
 install_pip instaloader                                                           # Instaloader
 install_go github.com/tdh8316/investigo@latest investigo                          # Investigo
 install_git https://github.com/l4rm4nd/LinkedInDumper.git LinkedInDumper          # LinkedInDumper

--- a/tools.json
+++ b/tools.json
@@ -7493,6 +7493,32 @@
     "archived": false
   },
   {
+    "id": "insta-dl",
+    "name": "insta-dl",
+    "description": "Async Instagram downloader for profiles, posts, reels, stories, highlights, hashtags, and comments",
+    "category": "username-social",
+    "url": "https://github.com/subzeroid/insta-dl",
+    "install": {
+      "method": "pip",
+      "kali": "`pip install instagram-dl`",
+      "raw": "`pip install instagram-dl`"
+    },
+    "tags": [
+      "username-social",
+      "curated-addition"
+    ],
+    "source_versions": [
+      "v3.3-expansion"
+    ],
+    "aliases": [
+      "instagram-dl"
+    ],
+    "sections_seen": [
+      "Social Media Monitoring"
+    ],
+    "archived": false
+  },
+  {
     "id": "instagram_monitor",
     "name": "instagram_monitor",
     "description": "Real-time tracking of Instagram users with email alerts and CSV logs",


### PR DESCRIPTION
## Summary
- Add `insta-dl` as an alternative Instagram downloader next to `Instaloader`.
- Add `insta-dl` to `tools.json` under `username-social` with the `instagram-dl` PyPI install command.
- Add `install_pip instagram-dl` to `osint.sh` and update visible tool counts from 751 to 752.

## Verification
- `jq empty tools.json`
- `jq 'length' tools.json` -> `752`
- `bash -n osint.sh install.sh blueteam.sh extras.sh forensics.sh hardware.sh labs.sh redteam.sh termux.sh`
- `git diff --check`
- `git ls-remote https://github.com/subzeroid/insta-dl.git HEAD`
- `curl -fsSL https://pypi.org/pypi/instagram-dl/json | jq -r '.info.name + " " + .info.version + " " + .info.project_url'` -> `instagram-dl 0.1.7 https://pypi.org/project/instagram-dl/`
