### PR TITLE
Add CheckLeaked WhatsApp to Phone Number OSINT

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,6 +458,7 @@ h8mail -t emails.txt
 | **GetContact** | See how number is saved by others | [getcontact.com](https://getcontact.com/) |
 | **NumVerify** | Phone number validation API | [numverify.com](https://numverify.com/) |
 | **Truecaller** | Caller ID & spam lookup | [truecaller.com](https://truecaller.com/) |
+| **CheckLeaked WhatsApp** | WhatsApp number lookup — profile pic history, About/bio, business-account detection | [whatsapp.checkleaked.cc](https://whatsapp.checkleaked.cc/) |
 | **Sync.me** | Phone number lookup | [sync.me](https://sync.me/) |
 | **CallerIDTest** | Reverse phone lookup | [calleridtest.com](https://calleridtest.com/) |
 | **SpyDialer** | Free reverse phone lookup | [spydialer.com](https://spydialer.com/) |


### PR DESCRIPTION
Adds one tool to **§3. Phone Number OSINT**:

| Tool | Description | Link |
|---|---|---|
| **CheckLeaked WhatsApp** | WhatsApp number lookup — profile-picture history, About/bio, business-account detection | https://whatsapp.checkleaked.cc/ |

CheckLeaked's breach-search engine is already listed in the leaks tables; this adds the separate WhatsApp lookup tool (a natural fit next to GetContact/Truecaller for number-based investigation).

*Disclosure: I'm affiliated with CheckLeaked. Link verified (HTTP 200); entry kept concise and factual per the list's format.*