### PR TITLE
Add IPOK to Domain & IP OSINT

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,6 +503,7 @@ pip install phoneinfoga
 | **Shodan** | Internet-connected device search | [shodan.io](https://shodan.io/) |
 | **Censys** | Internet-wide scan search | [censys.io](https://censys.io/) |
 | **Criminal IP** | AI-powered cyber threat intelligence | [criminalip.io](https://www.criminalip.io/) |
+| **IPOK** | Multi-source IP reputation & risk (proxy/VPN/Tor/datacenter detection, no login) | [ipok.io](https://ipok.io/) |
 | **VirusTotal** | Domain/IP/file analysis | [virustotal.com](https://virustotal.com/) |
 | **SecurityTrails** | DNS & domain intelligence | [securitytrails.com](https://securitytrails.com/) |
 | **IPGeoLocation** | IP address geolocation | `git clone https://github.com/maldevel/IPGeoLocation` |


### PR DESCRIPTION
Adds **IPOK** (https://ipok.io/) to the Domain & IP OSINT table.

IPOK is a free, no-login IP reputation & risk checker that aggregates multiple sources to flag proxy / VPN / Tor and datacenter vs residential, profiles /24 neighbors, and shows each source's verdict side by side (plus a CLI and Chrome extension). Placed next to Criminal IP / VirusTotal in the IP-intelligence cluster. Single one-line table row.