### PR TITLE
Add Fylings to §20 Financial & Corporate Intelligence

### DIFF
--- a/README.md
+++ b/README.md
@@ -1018,6 +1018,7 @@ bash zphisher.sh
 | Tool | Description | Link |
 |------|-------------|------|
 | **OpenCorporates** | Global corporate database | [opencorporates.com](https://opencorporates.com/) |
+| **Fylings** | African company registries -- 18+ jurisdictions, ownership data, sanctions screening | [fylings.com](https://www.fylings.com/) |
 | **ICIJ Offshore Leaks** | Panama/Pandora/Paradise Papers | [offshoreleaks.icij.org](https://offshoreleaks.icij.org/) |
 | **SEC EDGAR** | US company filings | [sec.gov/edgar](https://sec.gov/edgar) |
 | **Companies House (UK)** | UK company register | [beta.companieshouse.gov.uk](https://beta.companieshouse.gov.uk/) |


### PR DESCRIPTION
One tool, one section — added to **20. Financial & Corporate Intelligence**, next to OpenCorporates.

**Disclosure: this is my own project.**

`| **Fylings** | African company registries -- 18+ jurisdictions, ownership data, sanctions screening | [fylings.com](https://www.fylings.com/) |`

**Why it's on-topic:** the section covers OpenCorporates, Companies House and Aleph, but African jurisdictions are a gap. Fylings aggregates 18+ official national registries (Nigeria CAC, Tanzania BRELA, Mauritius CBRD, Senegal RCCM and others) into one free search, with the source registry and a last-verified date shown per record. Also carries beneficial-ownership records and government-contract awards.

**On durability:** own domain, not a free subdomain — live since 2026, funded, actively maintained. Free to search without an account.

Nothing installable, so no `tools.json` / installer / badge changes needed. Checked the README first, no existing entry or name clash.