### PR TITLE
Add DomScan API to OSINT developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1460,6 +1460,7 @@ python3 cupp.py -i
 | **Google Custom Search API** | Programmable search | [developers.google.com/custom-search](https://developers.google.com/custom-search) |
 | **WhoisXML API** | Domain intelligence | [whoisxmlapi.com](https://whoisxmlapi.com/) |
 | **Criminal IP API** | Threat intelligence | [criminalip.io/developer](https://www.criminalip.io/developer) |
+| **DomScan API** | Domain, DNS, WHOIS/RDAP, TLS, subdomain, reputation and brand intelligence | [domscan.net/docs](https://domscan.net/docs) |
 
 ---
 


### PR DESCRIPTION
Adds one factual row to **OSINT APIs & Developer Tools**. DomScan provides programmatic domain, DNS, WHOIS/RDAP, TLS, public-subdomain, reputation, and brand intelligence. The API has public documentation, self-service access, and a recurring free allowance.

Disclosure: I am the maintainer of DomScan. I am submitting it because it directly fits this API section; no installer or `tools.json` change is needed because this is a hosted API entry.

Validation: documentation returned HTTP 200 and `git diff --check` passed.