### PR TITLE
docs: add Metadata Viewer to OSINT tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1998,6 +1998,7 @@ sudo git clone https://github.com/RedSiege/EyeWitness
 | **meg** | Fetch many paths for many hosts without flooding | `go install github.com/tomnomnom/meg@latest` |
 | **[Memento Time Travel](https://timetravel.mementoweb.org)** | Federated search across multiple web archives | [timetravel.mementoweb.org](https://timetravel.mementoweb.org) |
 | **[Metadata2Go](https://www.metadata2go.com)** | Free online metadata extractor for any file | [metadata2go.com](https://www.metadata2go.com) |
+| **[Metadata Remover — Metadata Viewer](https://metadataremover.ai/metadata-viewer)** | Browser-local EXIF/IPTC/XMP inspection for images; corroborate forensic findings independently | [metadataremover.ai](https://metadataremover.ai/metadata-viewer) |
 | **[MetaDefender Cloud](https://metadefender.com)** | Multi-engine file/URL/IP scanning by OPSWAT | [metadefender.com](https://metadefender.com) |
 | **[MetaSleuth](https://metasleuth.io)** | Free + paid crypto transaction tracing tool | [metasleuth.io](https://metasleuth.io) |
 | **[MISP Galaxy](https://www.misp-galaxy.org)** | Adversary group identification used by SOCs/ISACs | [misp-galaxy.org](https://www.misp-galaxy.org) |


### PR DESCRIPTION
## Summary

- Add one Metadata Viewer row in the existing OSINT tools table.
- Use the repository's required one-line factual format and include an independent-corroboration limitation.

## Verification

The linked viewer is publicly accessible, free to use, and does not require an account. It performs image inspection in the browser.

Disclosure: I maintain MetadataRemover.ai.