### PR TITLE
Add StackScan to Domain & IP OSINT

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,6 +521,7 @@ pip install phoneinfoga
 | **Web-Check** | All-in-one website analysis | [web-check.xyz](https://web-check.xyz/) |
 | **IPinfo** | IP address data & geolocation | [ipinfo.io](https://ipinfo.io/) |
 | **DB-IP** | IP geolocation database | [db-ip.com](https://db-ip.com/) |
+| **StackScan** | Tech stack & asset footprint search | [stackscan.com](https://www.stackscan.com/) |
 
 <details>
 <summary><b>💻 Amass + Subfinder + HTTPx — Most effective recon combo</b></summary>


### PR DESCRIPTION
Adds StackScan to section 4, Domain & IP OSINT, appended to the end of the table.

**Disclosure: I work on StackScan.** Flagging it since undisclosed self-promo gets closed.

Three lookups that matter for recon:

- **Domain to stack.** What a given site runs.
- **Technology to sites.** Pick a technology and get the sites and companies running it, with country and industry breakdowns.
- **Custom Scan.** Search the raw asset index beneath the technology catalogue. Give it a file name, an asset path, or the host an asset loads from, and get every site carrying that footprint.

The third one is the reason I think it belongs here. A technology catalogue can only contain what someone wrote a detector for, so a niche plugin, a specific theme build, an internal SDK or a library version with a CVE against it has no entry. Custom Scan works from the asset index instead, so nothing has to be named or classified first. If a site loads the file, you can find the site.

Free tier on email verification: 100 lifetime API credits, one list, and custom footprint scans. Technology statistics pages are browsable with no account.

Description is 35 characters, within the range of the rest of the table. Link is a stable apex domain, not a temporary subdomain.
