### PR TITLE
Add Scweet to Social Media Monitoring (disclosed self-submission)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 <br/>
 
-[![Tools](https://img.shields.io/badge/Tools-753%2B-FF4444?style=for-the-badge&logo=target&logoColor=white)](https://github.com/rawfilejson/awesome-osint-arsenal)
+[![Tools](https://img.shields.io/badge/Tools-754%2B-FF4444?style=for-the-badge&logo=target&logoColor=white)](https://github.com/rawfilejson/awesome-osint-arsenal)
 [![Categories](https://img.shields.io/badge/Categories-50-0066CC?style=for-the-badge&logo=buffer&logoColor=white)](https://github.com/rawfilejson/awesome-osint-arsenal)
 [![Version](https://img.shields.io/badge/Version-2.1-00CC66?style=for-the-badge&logoColor=white)](https://github.com/rawfilejson/awesome-osint-arsenal)
 [![Updated](https://img.shields.io/badge/Updated-2026--05--10-FF8800?style=for-the-badge&logoColor=white)](https://github.com/rawfilejson/awesome-osint-arsenal)
@@ -18,7 +18,7 @@
 
 <br/>
 
-> **753+ tools · 50 categories · Multi-distro installers · Georgian OSINT · Termux support**
+> **754+ tools · 50 categories · Multi-distro installers · Georgian OSINT · Termux support**
 >
 > *The most comprehensive OSINT and security toolkit on the internet — every tool with installation instructions or a verified link.*
 
@@ -677,6 +677,7 @@ exiftool /path/to/images/
 | **insto** | Interactive Instagram OSINT CLI with REPL, snapshots, diffs, and Maltego exports | `pip install insto` |
 | **Twint** | Twitter OSINT (no API needed) | `pip install twint` |
 | **snscrape** | Social media scraper (Twitter, Reddit, etc.) | `pip install snscrape` |
+| **Scweet** | Twitter/X scraper, no API key needed | `pip install Scweet` |
 | **Toutatis** | Instagram OSINT by phone/email | `pip install toutatis` |
 | **TikTok Scraper** | TikTok data extraction | `npm install -g tiktok-scraper` |
 | **Reddit Investigator** | Reddit user analysis | [reddit-user-analyser.netlify.app](https://reddit-user-analyser.netlify.app/) |

--- a/tools.json
+++ b/tools.json
@@ -14063,6 +14063,29 @@
     "archived": false
   },
   {
+    "id": "scweet",
+    "name": "Scweet",
+    "description": "Twitter/X scraper, no API key needed",
+    "category": "username-social",
+    "url": "",
+    "install": {
+      "method": "pip",
+      "kali": "`pip install Scweet`",
+      "raw": "`pip install Scweet`"
+    },
+    "tags": [
+      "username-social"
+    ],
+    "source_versions": [
+      "v1"
+    ],
+    "aliases": [],
+    "sections_seen": [
+      "Social Media Monitoring"
+    ],
+    "archived": false
+  },
+  {
     "id": "snusbase",
     "name": "Snusbase",
     "description": "Breach data search engine",


### PR DESCRIPTION
**Disclosure: I wrote Scweet.** Treating this as a disclosed self-submission under CONTRIBUTING.md.

### What this PR does

One row in `## 8. Social Media Monitoring`, the matching `tools.json` entry, and the tool counts bumped from 753 to 754 in the badge and the summary line, as CONTRIBUTING.md asks.

```
| **Scweet** | Twitter/X scraper, no API key needed | `pip install Scweet` |
```

MIT, on PyPI, and I verified `pip install Scweet` in a clean Python 3.12.13 virtual environment before opening this.

### Why I came here

Two existing entries in the same section no longer work. I tested both today in a clean Python 3.12.13 venv.

**snscrape** installs, then fails at import before it makes any request:

```
  File ".../site-packages/snscrape/modules/__init__.py", line 13, in _import_modules
    module = importer.find_module(moduleName).load_module(moduleName)
             ^^^^^^^^^^^^^^^^^^^^
AttributeError: 'FileFinder' object has no attribute 'find_module'
```

Python 3.12 removed `importlib.abc.Finder.find_module`. The installed version is `0.7.0.20230622`, the last release, from June 2023. The git version fails the same way.

**twint** does not install at all:

```
ERROR: Failed building wheel for cchardet
ERROR: Failed to build installable wheels for some pyproject.toml based projects (cchardet)
```

`twintproject/twint` is archived, last push 2023-02-23.

### What I deliberately did not touch

I left the `twint` and `snscrape` rows alone, and I left the **Pro tip** line above the table that recommends snscrape. Those are your entries and your call. Tell me which you prefer and I will send a second PR:

- mark both as archived or unmaintained in your existing format, or
- remove them, and update the Pro tip line

I also did not add Scweet anywhere else, per the one-tool-one-section rule.

Happy to change the wording, the description, or the section.
